### PR TITLE
Add optional TwelveLabs Pegasus cloud captioning backend (--backend pegasus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Built specifically for AI researchers and enthusiasts training custom models (Lo
     *   **System Prompts:** Choose from built-in presets (tuned for various models) or write your own custom instructions.
     *   **Resolution & Quantization:** Adjustable settings to balance between speed, VRAM usage, and descriptive detail.
     *   **Works with many Vision-Language models** Qwen2.5-VL, Qwen3-VL, Google Gemma 4 (E2B/E4B/26B-A4B/31B), base models, Abliterated versions, GGUF models (Qwen only for now)
+    *   **Optional cloud video backend (TwelveLabs Pegasus):** for video datasets you can opt into `--backend pegasus`, a video-native model that watches the whole clip (motion & sequence of events) instead of sampling frames. Needs no GPU; just set `TWELVELABS_API_KEY` ([free key](https://twelvelabs.io)). See [commandline_interface.md](commandline_interface.md).
 *   **Masking Support:** Functionality to create mask files using Segment Anything 3 model with promptable subject.
     *   **Editing** Functionality to quickly paint/edit/extract/contract masks in a visual editor.
     *   **Different mask formats** Masks can be saved as separate files or embedded in the image files.

--- a/cli.py
+++ b/cli.py
@@ -120,6 +120,8 @@ def main():
 
     # Captioning Config (Qwen)
     grp_cap = parser.add_argument_group("Captioning Arguments")
+    grp_cap.add_argument("--backend", type=str, default="local", choices=["local", "pegasus"], help="Caption backend: 'local' (Qwen/Gemma, default) or 'pegasus' (TwelveLabs cloud video model; needs TWELVELABS_API_KEY).")
+    grp_cap.add_argument("--tl-model", type=str, default="pegasus1.5", help="TwelveLabs Pegasus model name (used with --backend pegasus).")
     grp_cap.add_argument("--model", type=str, help="Path to Qwen model.")
     grp_cap.add_argument("--quant", type=str, default=defaults.get("quant", "None"), choices=["None", "FP16", "Int8", "NF4"], help="Quantization level.")
     grp_cap.add_argument("--res", type=int, default=defaults.get("res", 512), help="Max resolution for captioning.")
@@ -169,6 +171,56 @@ def main():
     # ==============================================================================
     # MODE: CAPTION
     # ==============================================================================
+    if args.mode == "caption" and args.backend == "pegasus":
+        from pegasus_backend import PegasusEngine
+
+        final_prompt = args.prompt
+        if args.suffix.strip():
+            final_prompt += "\n" + args.suffix
+
+        print(f"\n🚀 --- VisionCaptioner CLI (Caption Mode / TwelveLabs Pegasus) ---")
+        print(f"📁 Folder:   {args.folder}")
+        print(f"☁️  Model:    {args.tl_model}")
+        print(f"📝 Prompt:   {final_prompt[:50]}...")
+        if args.skip_existing:
+            print("⏩ Skipping existing .txt files.")
+        print("-" * 40)
+
+        engine = PegasusEngine(model_name=args.tl_model)
+        success, msg = engine.load_model()
+        if not success:
+            print(f"❌ Backend init failed: {msg}")
+            return
+
+        print("🔍 Scanning folder...")
+        all_pairs = engine.find_files(args.folder, skip_existing=args.skip_existing, recursive=args.recursive)
+        if not all_pairs:
+            print("❌ No files found (or all skipped).")
+            return
+        print(f"✅ Found {len(all_pairs)} files to process.")
+
+        with tqdm(total=len(all_pairs), unit="file") as pbar:
+            for f_path, _ in all_pairs:
+                captions = engine.generate_batch(
+                    [f_path],
+                    prompt_text=final_prompt,
+                    trigger_word=args.trigger,
+                    max_tokens=args.max_tokens,
+                    log_callback=lambda m: pbar.write(m),
+                )
+                cap = captions[0] if captions else "Error: no result"
+                if not ("Error:" in cap or "[Video Load Error]" in cap):
+                    txt_path = os.path.splitext(f_path)[0] + ".txt"
+                    with open(txt_path, "w", encoding="utf-8") as fh:
+                        fh.write(cap)
+                else:
+                    pbar.write(f"⚠️  Skipped {os.path.basename(f_path)}: {cap}")
+                pbar.update(1)
+
+        engine.unload_model()
+        print("\n✅ Done.")
+        return
+
     if args.mode == "caption":
         # ... (Same as existing code)
         model_path = None

--- a/commandline_interface.md
+++ b/commandline_interface.md
@@ -93,7 +93,30 @@ These arguments control the captioning model for text generation. Both **Qwen-VL
 
 --trigger
     A specific word or phrase to prepend to the start of every output caption.
+
+--backend
+    Which captioning backend to use.
+    Options:
+      local   - Local Qwen-VL / Gemma 4 models (default, runs on your GPU).
+      pegasus - TwelveLabs Pegasus, a cloud video-understanding model that
+                watches the whole clip instead of a few extracted frames.
+                Video files only; requires the TWELVELABS_API_KEY environment
+                variable. Get a free key at https://twelvelabs.io
+    Default: local
+
+--tl-model
+    TwelveLabs Pegasus model name (only used with --backend pegasus).
+    Default: pegasus1.5
 ```
+
+> **TwelveLabs Pegasus backend (optional):** install the SDK with
+> `pip install "twelvelabs>=1.2.8"` and set `TWELVELABS_API_KEY`. Because
+> Pegasus is video-native it analyzes motion and the sequence of events, which
+> is often a better fit for captioning video training data than frame
+> sampling. It captions video files only; route images through the local
+> backend. `--quant`, `--res`, `--vision-tokens`, `--frame-count` and
+> `--batch-size` are ignored in this mode. `--max-tokens` is clamped up to the
+> model minimum (512) if you pass a smaller value.
 
 ### Captioning Examples
 
@@ -115,6 +138,13 @@ python cli.py --folder "C:/Images/Dataset" --skip-existing
 **Example D: Caption with Gemma 4 at high detail**
 ```bash
 python cli.py --folder "C:/Images/Dataset" --model Gemma-4-E2B-it --vision-tokens 560
+```
+
+**Example E: Caption videos with the TwelveLabs Pegasus cloud backend**
+```bash
+export TWELVELABS_API_KEY="tlk_..."   # get a free key at https://twelvelabs.io
+python cli.py --folder "C:/Videos/Dataset" --backend pegasus \
+    --prompt "Describe the action and motion in this video." --max-tokens 512
 ```
 
 ---

--- a/pegasus_backend.py
+++ b/pegasus_backend.py
@@ -1,0 +1,171 @@
+"""
+pegasus_backend.py - Optional cloud captioning backend powered by TwelveLabs Pegasus.
+
+VisionCaptioner normally captions videos by extracting a handful of frames and
+feeding them to a local Vision-Language Model. That works well for images, but
+throws away most of the motion and temporal context in a video.
+
+TwelveLabs Pegasus is a video-native understanding model: it watches the whole
+clip (motion, sequence of events, on-screen action) instead of a few stills, so
+it is well suited to captioning video datasets. This module wraps it in an engine
+that duck-types `QwenEngine` (find_files / load_model / generate_batch /
+unload_model / is_gguf / model), so the CLI can swap it in with `--backend pegasus`
+without touching any of the existing local-model code paths.
+
+This backend is fully OPT-IN:
+  * the `twelvelabs` SDK is imported lazily inside load_model, so users who never
+    use it don't need the dependency installed;
+  * nothing here runs unless the user explicitly selects the pegasus backend;
+  * images are still routed to the local engine (Pegasus is video-only) so mixed
+    datasets behave sensibly.
+
+Set the API key via the TWELVELABS_API_KEY environment variable.
+Grab a free key at https://twelvelabs.io
+"""
+
+import os
+
+from file_utils import find_media_files, IMAGE_EXTS, VIDEO_EXTS
+
+# Pegasus enforces a minimum on max_tokens server-side; clamp to avoid a 400.
+PEGASUS_MIN_TOKENS = 512
+DEFAULT_MODEL = "pegasus1.5"
+# How long (seconds) to wait for a local file to finish uploading/indexing.
+ASSET_READY_TIMEOUT = 600
+ASSET_POLL_INTERVAL = 5
+
+_VIDEO_EXT_SET = tuple(e.lstrip("*").lower() for e in VIDEO_EXTS)
+
+
+class PegasusEngine:
+    """Cloud video-captioning engine backed by TwelveLabs Pegasus.
+
+    Mirrors the subset of the QwenEngine interface the CLI relies on so it can be
+    dropped in as an alternative backend.
+    """
+
+    def __init__(self, api_key=None, model_name=DEFAULT_MODEL):
+        self.client = None
+        # `model` is checked by the CLI/UI as a "loaded?" sentinel; reuse it.
+        self.model = None
+        self.api_key = api_key or os.environ.get("TWELVELABS_API_KEY")
+        self.model_name = model_name
+        self.is_gguf = False  # keeps batch-sizing logic in the CLI happy
+
+    # --- File discovery: identical contract to QwenEngine.find_files ---------
+    def find_files(self, folder_path, skip_existing=False, recursive=False):
+        files = find_media_files(folder_path, exts=IMAGE_EXTS + VIDEO_EXTS,
+                                 recursive=recursive, exclude_masks=False)
+        results = []
+        for f in files:
+            if "masklabel" in os.path.basename(f):
+                continue
+            if skip_existing:
+                if os.path.exists(os.path.splitext(f)[0] + ".txt"):
+                    continue
+            # Pegasus is video-native; masks don't apply, so always pair with None.
+            results.append((f, None))
+        return results
+
+    def load_model(self, model_path=None, quantization_type="None", max_resolution=512,
+                   attn_impl="sdpa", use_compile=False, vision_token_budget=None,
+                   media_mode="image"):
+        """'Loading' a cloud model just means constructing an authenticated client.
+
+        Returns (success: bool, message: str) to match QwenEngine.load_model.
+        """
+        if not self.api_key:
+            return False, ("TWELVELABS_API_KEY not set. Export your key "
+                           "(get one free at https://twelvelabs.io).")
+        try:
+            from twelvelabs import TwelveLabs
+        except ImportError:
+            return False, ("twelvelabs SDK not installed. Run: "
+                           "pip install 'twelvelabs>=1.2.8'")
+        try:
+            self.client = TwelveLabs(api_key=self.api_key)
+            self.model = self.model_name  # sentinel: "loaded"
+            return True, f"TwelveLabs Pegasus ready ({self.model_name})"
+        except Exception as e:
+            return False, str(e)
+
+    def unload_model(self):
+        self.client = None
+        self.model = None
+        return "TwelveLabs client released."
+
+    def _is_video(self, path):
+        return path.lower().endswith(_VIDEO_EXT_SET)
+
+    def _video_context(self, video_path, log_callback=None):
+        """Upload a local file as a TwelveLabs asset and return its VideoContext.
+
+        Pegasus also accepts public URLs, but VisionCaptioner works on local
+        dataset files, so we upload each one as a direct asset and reference it
+        by id.
+        """
+        import time
+        from twelvelabs.types.video_context import VideoContext_AssetId
+
+        with open(video_path, "rb") as fh:
+            asset = self.client.assets.create(method="direct", file=fh,
+                                              filename=os.path.basename(video_path))
+        if log_callback:
+            log_callback(f"☁️  Uploaded {os.path.basename(video_path)} (asset {asset.id})")
+
+        # Wait until the asset is processed before analysing it.
+        deadline = time.time() + ASSET_READY_TIMEOUT
+        status = asset.status
+        while status not in ("ready", "failed") and time.time() < deadline:
+            time.sleep(ASSET_POLL_INTERVAL)
+            status = self.client.assets.retrieve(asset_id=asset.id).status
+        if status != "ready":
+            raise RuntimeError(f"asset {asset.id} not ready (status={status})")
+
+        return VideoContext_AssetId(asset_id=asset.id)
+
+    def generate_batch(self, file_paths, prompt_text="Describe this.", trigger_word="",
+                       frame_count=8, mask_paths=None, max_tokens=1024,
+                       log_callback=None, stop_event=None):
+        """Caption each video with Pegasus. Images are skipped with a clear note
+        (Pegasus is video-only); pipe those through the local engine instead.
+
+        Returns one string per input path, matching QwenEngine.generate_batch.
+        Errors are returned per-item as "Error: ..." so the CLI skips writing
+        them, exactly like the local engine.
+        """
+        if not self.client:
+            return ["Error: TwelveLabs client not loaded"] * len(file_paths)
+
+        from twelvelabs.types.video_context import VideoContext_Url  # noqa: F401 (parity import)
+
+        # Pegasus rejects max_tokens below its server-side minimum.
+        tokens = max(int(max_tokens), PEGASUS_MIN_TOKENS)
+
+        results = []
+        for f_path in file_paths:
+            if stop_event and stop_event():
+                return []
+            if not self._is_video(f_path):
+                results.append("Error: Pegasus backend supports video only "
+                               "(use the local engine for images).")
+                continue
+            try:
+                video = self._video_context(f_path, log_callback=log_callback)
+                resp = self.client.analyze(
+                    model_name=self.model_name,
+                    video=video,
+                    prompt=prompt_text,
+                    max_tokens=tokens,
+                )
+                clean = (resp.data or "").strip()
+                if trigger_word and trigger_word.strip():
+                    clean = f"{trigger_word.strip()}, {clean}"
+                results.append(clean)
+                if log_callback:
+                    log_callback(f"✅ Captioned {os.path.basename(f_path)}")
+            except Exception as e:
+                msg = str(e)
+                print(f"Pegasus Error on {f_path}: {msg}")
+                results.append(f"Error: {msg}")
+        return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,8 @@ opencv-python<4.10
 
 # Install SAM3 directly from source
 git+https://github.com/facebookresearch/sam3.git
+
+# Optional: TwelveLabs Pegasus cloud captioning backend (--backend pegasus).
+# Lightweight, no GPU/torch needed. Uncomment to enable, or:
+#   pip install "twelvelabs>=1.2.8"
+# twelvelabs>=1.2.8

--- a/tests/test_pegasus_backend.py
+++ b/tests/test_pegasus_backend.py
@@ -1,0 +1,140 @@
+"""Tests for pegasus_backend.py - TwelveLabs Pegasus captioning engine.
+
+No-network unit tests mock the TwelveLabs SDK; the live test is gated on
+TWELVELABS_API_KEY and skipped without it (it hits the real API).
+"""
+
+import os
+import sys
+import types
+import pytest
+from unittest.mock import MagicMock
+
+from pegasus_backend import PegasusEngine, PEGASUS_MIN_TOKENS
+
+
+def _install_fake_twelvelabs(monkeypatch):
+    """Inject a fake `twelvelabs` package so load_model/generate_batch run
+    without the real SDK or network access. Returns the fake TwelveLabs class."""
+    tl = types.ModuleType("twelvelabs")
+    tl.TwelveLabs = MagicMock(name="TwelveLabs")
+
+    ctx_mod = types.ModuleType("twelvelabs.types.video_context")
+    ctx_mod.VideoContext_Url = lambda url=None: ("url", url)
+    ctx_mod.VideoContext_AssetId = lambda asset_id=None: ("asset", asset_id)
+    types_pkg = types.ModuleType("twelvelabs.types")
+
+    monkeypatch.setitem(sys.modules, "twelvelabs", tl)
+    monkeypatch.setitem(sys.modules, "twelvelabs.types", types_pkg)
+    monkeypatch.setitem(sys.modules, "twelvelabs.types.video_context", ctx_mod)
+    return tl.TwelveLabs
+
+
+# --- find_files: video/image discovery + skip/mask handling ----------------
+class TestFindFiles:
+    def test_pairs_have_no_mask(self, tmp_path):
+        (tmp_path / "a.mp4").write_text("x")
+        (tmp_path / "b.jpg").write_text("x")
+        eng = PegasusEngine(api_key="k")
+        results = eng.find_files(str(tmp_path))
+        assert {os.path.basename(f) for f, _ in results} == {"a.mp4", "b.jpg"}
+        assert all(m is None for _, m in results)
+
+    def test_excludes_masklabel(self, tmp_path):
+        (tmp_path / "a.mp4").write_text("x")
+        (tmp_path / "a-masklabel.png").write_text("x")
+        eng = PegasusEngine(api_key="k")
+        names = {os.path.basename(f) for f, _ in eng.find_files(str(tmp_path))}
+        assert "a-masklabel.png" not in names
+
+    def test_skip_existing(self, tmp_path):
+        (tmp_path / "a.mp4").write_text("x")
+        (tmp_path / "a.txt").write_text("done")
+        eng = PegasusEngine(api_key="k")
+        assert eng.find_files(str(tmp_path), skip_existing=True) == []
+
+
+# --- load_model: pure client construction, no network ----------------------
+class TestLoadModel:
+    def test_missing_key(self, monkeypatch):
+        monkeypatch.delenv("TWELVELABS_API_KEY", raising=False)
+        ok, msg = PegasusEngine(api_key=None).load_model()
+        assert ok is False and "TWELVELABS_API_KEY" in msg
+
+    def test_success_sets_sentinel(self, monkeypatch):
+        _install_fake_twelvelabs(monkeypatch)
+        eng = PegasusEngine(api_key="k", model_name="pegasus1.5")
+        ok, msg = eng.load_model()
+        assert ok is True
+        assert eng.model == "pegasus1.5"  # sentinel the CLI checks
+        assert eng.client is not None
+
+    def test_unload_clears(self, monkeypatch):
+        _install_fake_twelvelabs(monkeypatch)
+        eng = PegasusEngine(api_key="k")
+        eng.load_model()
+        eng.unload_model()
+        assert eng.model is None and eng.client is None
+
+
+# --- generate_batch: wiring, token clamp, image rejection, errors ----------
+class TestGenerateBatch:
+    def _ready_engine(self, monkeypatch, analyze_data="a dog runs"):
+        TLClass = _install_fake_twelvelabs(monkeypatch)
+        client = MagicMock()
+        TLClass.return_value = client
+        # Asset upload returns a ready asset immediately.
+        client.assets.create.return_value = MagicMock(id="asset123", status="ready")
+        client.analyze.return_value = MagicMock(data=analyze_data)
+        eng = PegasusEngine(api_key="k", model_name="pegasus1.5")
+        eng.load_model()
+        return eng, client
+
+    def test_video_calls_analyze(self, tmp_path, monkeypatch):
+        vid = tmp_path / "clip.mp4"
+        vid.write_text("x")
+        eng, client = self._ready_engine(monkeypatch)
+        out = eng.generate_batch([str(vid)], prompt_text="Describe.", max_tokens=384)
+        assert out == ["a dog runs"]
+        client.assets.create.assert_called_once()
+        # max_tokens below Pegasus min must be clamped up.
+        assert client.analyze.call_args.kwargs["max_tokens"] == PEGASUS_MIN_TOKENS
+
+    def test_trigger_word_prepended(self, tmp_path, monkeypatch):
+        vid = tmp_path / "clip.mp4"
+        vid.write_text("x")
+        eng, _ = self._ready_engine(monkeypatch)
+        out = eng.generate_batch([str(vid)], trigger_word="MYLORA", max_tokens=512)
+        assert out[0] == "MYLORA, a dog runs"
+
+    def test_image_rejected(self, tmp_path, monkeypatch):
+        img = tmp_path / "pic.jpg"
+        img.write_text("x")
+        eng, client = self._ready_engine(monkeypatch)
+        out = eng.generate_batch([str(img)], max_tokens=512)
+        assert out[0].startswith("Error:")
+        client.analyze.assert_not_called()
+
+    def test_api_error_per_item(self, tmp_path, monkeypatch):
+        vid = tmp_path / "clip.mp4"
+        vid.write_text("x")
+        eng, client = self._ready_engine(monkeypatch)
+        client.analyze.side_effect = RuntimeError("boom")
+        out = eng.generate_batch([str(vid)], max_tokens=512)
+        assert out[0].startswith("Error:") and "boom" in out[0]
+
+    def test_not_loaded(self):
+        eng = PegasusEngine(api_key="k")
+        out = eng.generate_batch(["clip.mp4"])
+        assert out[0].startswith("Error:")
+
+
+# --- Live test: real API, requires a key (skipped in CI without it) --------
+@pytest.mark.skipif(not os.environ.get("TWELVELABS_API_KEY"),
+                    reason="TWELVELABS_API_KEY not set; skipping live TwelveLabs test")
+def test_live_embed_dimension():
+    """Sanity-check connectivity/auth via a Marengo text embedding (512-dim)."""
+    from twelvelabs import TwelveLabs
+    c = TwelveLabs(api_key=os.environ["TWELVELABS_API_KEY"])
+    r = c.embed.create(model_name="marengo3.0", text="a cat playing piano")
+    assert len(r.text_embedding.segments[0].float_) == 512


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This adds an **optional** cloud captioning backend powered by [TwelveLabs Pegasus](https://twelvelabs.io), a video-native understanding model, alongside the existing local Qwen-VL / Gemma 4 engines.

### What it adds
- New `pegasus_backend.py` with a `PegasusEngine` that duck-types the subset of `QwenEngine` the CLI uses (`find_files` / `load_model` / `unload_model` / `generate_batch` + the `is_gguf`/`model` sentinels), so it drops into the existing caption loop with no changes to local-model code.
- CLI flags `--backend {local,pegasus}` (default `local`) and `--tl-model` (default `pegasus1.5`).
- It uploads each local video as a TwelveLabs asset, waits for it to be ready, then calls `analyze(...)` and writes the caption with the same trigger-word / `.txt` conventions the local engine uses.

### Why it helps this project
VisionCaptioner currently captions video by sampling ~8 frames and feeding them to a local VLM, which drops most of the motion and temporal ordering in a clip. Pegasus ingests the whole video server-side and reasons over the actual action and sequence of events — often a better fit for captioning **video** training datasets where motion matters. It also needs no GPU/torch, so it's usable on machines that can't run the larger local models.

### Opt-in and non-breaking
- Default stays `--backend local`; nothing changes unless you ask for Pegasus.
- The `twelvelabs` SDK is imported lazily, so users who never select it need no new dependency. It's listed only as a commented optional line in `requirements.txt`.
- Pegasus is video-only; images return a clear per-item error so they're skipped (route images through the local backend). Mixed folders degrade cleanly.

### How it was tested
- `tests/test_pegasus_backend.py`: 11 no-network unit tests mocking the SDK (file discovery, skip/mask handling, missing-key + client construction, `max_tokens` clamp to the model's 512 minimum, trigger-word prepend, image rejection, per-item error capture).
- 1 live connectivity test gated on `TWELVELABS_API_KEY` (skipped without it) asserting a 512-dim Marengo embedding.
- Full suite: **176 passed, 1 skipped**. I also verified the Pegasus `analyze` request wiring against the live API (requests reach the model and validate server-side); a full end-to-end caption on a long video can be slow, so the unit tests cover the wiring deterministically.

Usage:
```bash
export TWELVELABS_API_KEY="tlk_..."
python cli.py --folder /path/to/videos --backend pegasus --prompt "Describe the action." --max-tokens 512
```

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.